### PR TITLE
Move pages deploy to main branch workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 KOINSLOT, Inc.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Deploy
+on:
+  push:
+    branches:
+    - main
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - run: pip install pipenv
+    - run: sudo apt-get install doxygen
+    - run: make docs
+    - uses: actions/upload-pages-artifact@v3
+
+  deploy-docs:
+    needs: build-docs
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,28 +49,3 @@ jobs:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         prerelease: false
         automatic_release_tag: ${{ needs.version.outputs.new_tag }}
-
-  build-docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - run: pip install pipenv
-    - run: sudo apt-get install doxygen
-    - run: make docs
-    - uses: actions/upload-pages-artifact@v3
-
-  deploy-docs:
-    needs: build-docs
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4
-

--- a/library.properties
+++ b/library.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 name=Kywy
-version=1.7.0
+version=1.8.0
 author=KOINSLOT, Inc.
 maintainer=KOINSLOT, Inc <info@kywy.io>
 sentence=The core Kywy engine.


### PR DESCRIPTION
The [previous](https://github.com/KOINSLOT-Inc/kywy/actions/runs/14537654173/job/40789209343) deploy failed because the release workflow runs on closed PRs and not on `main` (can't find why I did this 😅, probably copypasta). This MR moves the pages deploy to another workflow that runs on `main` so it can have permissions to do the pages deploy.