### PR TITLE
fix issue with bump recognition

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: check proposed version bump
       id: tag
       uses: anothrNick/github-tag-action@1.71.0
@@ -42,6 +44,7 @@ jobs:
         WITH_V: true
         INITIAL_VERSION: 1.0.0
         DRY_RUN: true
+        VERBOSE: true
     - name: assert version in library.properties is bumped
       run: |
         if [ \

--- a/library.properties
+++ b/library.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 name=Kywy
-version=1.8.0
+version=1.8.1
 author=KOINSLOT, Inc.
 maintainer=KOINSLOT, Inc <info@kywy.io>
 sentence=The core Kywy engine.


### PR DESCRIPTION
by default the checkout step gets a merge commit instead of the branch head which messes up the analysis of the #bump stuff (see https://github.com/actions/checkout/issues/426)

We change the checkout behavior for just the license version check.