### PR TITLE
Move release to main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,7 @@
 
 name: Release
 on:
-  pull_request:
-    types:
-    - closed
+  push:
     branches:
     - main
     paths:  # Only trigger if these files were changed


### PR DESCRIPTION
Running releases on PR merges failed when merging an external fork.