### PR TITLE
fix: Handle sdcard initalization sequence to prevent sdcard bus interference.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 name=Kywy
-version=1.18.0
+version=1.18.1
 author=KOINSLOT, Inc.
 maintainer=KOINSLOT, Inc <info@kywy.io>
 sentence=The core Kywy engine.

--- a/src/SPIBus.cpp
+++ b/src/SPIBus.cpp
@@ -104,6 +104,45 @@ extern "C" void spi_bus_dma_irq_handler(void) {
   }
 }
 
+void resetSDCard() {
+  if (!mbedSPI) {
+    return;  // SPI not initialized yet
+  }
+
+  // Put SD card into proper SPI mode by sending CMD0 (GO_IDLE_STATE)
+
+  // Very handy source: https://elm-chan.org/docs/mmc/mmc_e.html
+
+  // Send 80+ dummy clocks with CS high (per SD spec requirement)
+  for (int i = 0; i < 12; i++) {
+    mbedSPI->write(0xFF);
+  }
+  
+  // Send CMD0 to reset SD card into SPI mode
+  digitalWrite(KYWY_EXP1_CS, LOW);
+  delayMicroseconds(10);
+  mbedSPI->write(0x40);  // CMD0
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x95);  // CRC for CMD0
+  mbedSPI->write(0xFF);  // Throwaway bit
+  
+  // Wait for and read R1 response or timeout
+  for (int i = 0; i < 20; i++) { // timeout at 20 tries (possibly no sdcard)
+    uint8_t response = mbedSPI->write(0xFF);
+    if (response != 0xFF) break;
+  }
+  
+  digitalWrite(KYWY_EXP1_CS, HIGH);  // Disable SD card CS
+  
+  // Send additional clocks to complete initialization
+  for (int i = 0; i < 10; i++) {
+    mbedSPI->write(0xFF);
+  }
+}
+
 void initialize() {
   // Create mbed::SPI object to initialize SPI hardware
   // Keep this object private to SPIBus - it should only be accessed internally
@@ -114,50 +153,18 @@ void initialize() {
   // Configure MISO with pull-down to reduce crosstalk from SD card
   pinMode(KYWY_MISO, INPUT_PULLDOWN);
 
-  // Asume things are plugged in and we need to deselect them to prevent bus conflicts
+  // Assume things are plugged in and we need to deselect them to prevent bus conflicts
   // Assume default EXP devices are active high (eg SD card, common convention)
   pinMode(KYWY_DISPLAY_CS, OUTPUT);
-  pinMode(KYWY_SDCARD_CS, OUTPUT);
   pinMode(KYWY_EXP1_CS, OUTPUT);
   pinMode(KYWY_EXP2_CS, OUTPUT);
 
-  digitalWrite(KYWY_DISPLAY_CS, LOW);
-  digitalWrite(KYWY_SDCARD_CS, HIGH);
-  digitalWrite(KYWY_EXP1_CS, HIGH);
-  digitalWrite(KYWY_EXP2_CS, HIGH);
+  digitalWrite(KYWY_DISPLAY_CS, LOW);   // Active low
+  digitalWrite(KYWY_EXP1_CS, HIGH);     // Active high
+  digitalWrite(KYWY_EXP2_CS, HIGH);     // Active high
 
-  // Put SD card into proper SPI mode by sending CMD0 (GO_IDLE_STATE)
-  // This ensures SD card MISO output is properly tri-stated
-  delay(10);  // Power-on delay
-  
-  // Send 80+ dummy clocks with CS high (per SD spec requirement)
-  for (int i = 0; i < 10; i++) {
-    mbedSPI->write(0xFF);
-  }
-  
-  // Send CMD0 to reset SD card into SPI mode
-  digitalWrite(KYWY_SDCARD_CS, LOW);
-  delayMicroseconds(10);
-  mbedSPI->write(0x40);  // CMD0
-  mbedSPI->write(0x00);
-  mbedSPI->write(0x00);
-  mbedSPI->write(0x00);
-  mbedSPI->write(0x00);
-  mbedSPI->write(0x95);  // CRC for CMD0
-  
-  // Wait for and read R1 response
-  for (int i = 0; i < 10; i++) {
-    uint8_t response = mbedSPI->write(0xFF);
-    if (response != 0xFF) break;
-  }
-  
-  digitalWrite(KYWY_SDCARD_CS, HIGH);
-  delay(1);
-  
-  // Send additional clocks to complete initialization
-  for (int i = 0; i < 10; i++) {
-    mbedSPI->write(0xFF);
-  }
+  // Initialize SD card to prevent display artifacts
+  resetSDCard();
 }
 
 bool isBusLocked() {

--- a/src/SPIBus.cpp
+++ b/src/SPIBus.cpp
@@ -118,7 +118,7 @@ void resetSDCard() {
   for (int i = 0; i < 12; i++) {
     mbedSPI->write(0xFF);
   }
-  
+
   // Send CMD0 to reset SD card into SPI mode
   digitalWrite(KYWY_EXP1_CS, LOW);
   delayMicroseconds(10);
@@ -129,15 +129,15 @@ void resetSDCard() {
   mbedSPI->write(0x00);
   mbedSPI->write(0x95);  // CRC for CMD0
   mbedSPI->write(0xFF);  // Throwaway bit
-  
+
   // Wait for and read R1 response or timeout
-  for (int i = 0; i < 20; i++) { // timeout at 20 tries (possibly no sdcard)
+  for (int i = 0; i < 20; i++) {  // timeout at 20 tries (possibly no sdcard)
     uint8_t response = mbedSPI->write(0xFF);
     if (response != 0xFF) break;
   }
-  
+
   digitalWrite(KYWY_EXP1_CS, HIGH);  // Disable SD card CS
-  
+
   // Send additional clocks to complete initialization
   for (int i = 0; i < 10; i++) {
     mbedSPI->write(0xFF);
@@ -157,12 +157,12 @@ void initialize() {
   // Assume things are plugged in and we need to deselect them to prevent bus conflicts
   // Assume default EXP devices are active high (eg SD card, common convention)
   pinMode(KYWY_DISPLAY_CS, OUTPUT);
-  pinMode(KYWY_EXP1_CS, OUTPUT); // expansion port 1 CS (black pins on back) shared with sdcard, cant use pins and card at same time
-  pinMode(KYWY_EXP2_CS, OUTPUT); // expansion port 2 CS (black pins on back)
+  pinMode(KYWY_EXP1_CS, OUTPUT);  // expansion port 1 CS (black pins on back) shared with sdcard, cant use pins and card at same time
+  pinMode(KYWY_EXP2_CS, OUTPUT);  // expansion port 2 CS (black pins on back)
 
-  digitalWrite(KYWY_DISPLAY_CS, LOW);   // Active low
-  digitalWrite(KYWY_EXP1_CS, HIGH);     // Active high
-  digitalWrite(KYWY_EXP2_CS, HIGH);     // Active high
+  digitalWrite(KYWY_DISPLAY_CS, LOW);  // Active low
+  digitalWrite(KYWY_EXP1_CS, HIGH);    // Active high
+  digitalWrite(KYWY_EXP2_CS, HIGH);    // Active high
 
   // Initialize SD card to prevent display artifacts
   resetSDCard();

--- a/src/SPIBus.cpp
+++ b/src/SPIBus.cpp
@@ -105,12 +105,13 @@ extern "C" void spi_bus_dma_irq_handler(void) {
 }
 
 void resetSDCard() {
+  // TODO: implement this function on an sdcard insertion if we can try to detect it periodically
+
   if (!mbedSPI) {
     return;  // SPI not initialized yet
   }
 
   // Put SD card into proper SPI mode by sending CMD0 (GO_IDLE_STATE)
-
   // Very handy source: https://elm-chan.org/docs/mmc/mmc_e.html
 
   // Send 80+ dummy clocks with CS high (per SD spec requirement)
@@ -156,8 +157,8 @@ void initialize() {
   // Assume things are plugged in and we need to deselect them to prevent bus conflicts
   // Assume default EXP devices are active high (eg SD card, common convention)
   pinMode(KYWY_DISPLAY_CS, OUTPUT);
-  pinMode(KYWY_EXP1_CS, OUTPUT);
-  pinMode(KYWY_EXP2_CS, OUTPUT);
+  pinMode(KYWY_EXP1_CS, OUTPUT); // expansion port 1 CS (black pins on back) shared with sdcard, cant use pins and card at same time
+  pinMode(KYWY_EXP2_CS, OUTPUT); // expansion port 2 CS (black pins on back)
 
   digitalWrite(KYWY_DISPLAY_CS, LOW);   // Active low
   digitalWrite(KYWY_EXP1_CS, HIGH);     // Active high

--- a/src/SPIBus.cpp
+++ b/src/SPIBus.cpp
@@ -111,6 +111,9 @@ void initialize() {
   mbedSPI->format(8, 0);        // 8-bit, mode 0 (will be reconfigured per transfer)
   mbedSPI->frequency(2000000);  // 2MHz default (will be reconfigured per transfer)
 
+  // Configure MISO with pull-down to reduce crosstalk from SD card
+  pinMode(KYWY_MISO, INPUT_PULLDOWN);
+
   // Asume things are plugged in and we need to deselect them to prevent bus conflicts
   // Assume default EXP devices are active high (eg SD card, common convention)
   pinMode(KYWY_DISPLAY_CS, OUTPUT);
@@ -122,6 +125,39 @@ void initialize() {
   digitalWrite(KYWY_SDCARD_CS, HIGH);
   digitalWrite(KYWY_EXP1_CS, HIGH);
   digitalWrite(KYWY_EXP2_CS, HIGH);
+
+  // Put SD card into proper SPI mode by sending CMD0 (GO_IDLE_STATE)
+  // This ensures SD card MISO output is properly tri-stated
+  delay(10);  // Power-on delay
+  
+  // Send 80+ dummy clocks with CS high (per SD spec requirement)
+  for (int i = 0; i < 10; i++) {
+    mbedSPI->write(0xFF);
+  }
+  
+  // Send CMD0 to reset SD card into SPI mode
+  digitalWrite(KYWY_SDCARD_CS, LOW);
+  delayMicroseconds(10);
+  mbedSPI->write(0x40);  // CMD0
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x00);
+  mbedSPI->write(0x95);  // CRC for CMD0
+  
+  // Wait for and read R1 response
+  for (int i = 0; i < 10; i++) {
+    uint8_t response = mbedSPI->write(0xFF);
+    if (response != 0xFF) break;
+  }
+  
+  digitalWrite(KYWY_SDCARD_CS, HIGH);
+  delay(1);
+  
+  // Send additional clocks to complete initialization
+  for (int i = 0; i < 10; i++) {
+    mbedSPI->write(0xFF);
+  }
 }
 
 bool isBusLocked() {
@@ -151,8 +187,7 @@ bool startDMATransfer(uint8_t *buffer, size_t size, int csPin, bool csActiveHigh
   // Restore interrupts - we now own the lock
   restore_interrupts(interrupts);
 
-  // Configure SPI frequency for this transfer using mbed::SPI
-  // This must be done AFTER acquiring the lock to prevent race conditions
+  // Configure SPI frequency for this transfer
   mbedSPI->frequency(frequency);
 
   // Store CS pin info and callback
@@ -217,10 +252,12 @@ bool startDuplexDMATransfer(uint8_t *txBuffer, uint8_t *rxBuffer, size_t size, i
   }
   busLocked = true;
   restore_interrupts(interrupts);
+
   mbedSPI->frequency(frequency);
   currentCSPin = csPin;
   currentCSActiveHigh = csActiveHigh;
   currentCompletionCallback = completionCallback;
+
   if (csPin >= 0) digitalWrite(csPin, csActiveHigh ? HIGH : LOW);
 
   // Claim two DMA channels: one for TX, one for RX

--- a/src/SPIBus.hpp
+++ b/src/SPIBus.hpp
@@ -13,7 +13,6 @@
 #define KYWY_MISO 16
 
 #define KYWY_DISPLAY_CS 17
-#define KYWY_SDCARD_CS 15
 #define KYWY_EXP1_CS 15  // expansion port 1 CS (black pins on back) shared with sdcard, cant use pins and card at same time
 #define KYWY_EXP2_CS 14  // expansion port 2 CS (black pins on back)
 
@@ -25,6 +24,10 @@ namespace SPIBus {
 //   misoPin: MISO pin number
 //   sckPin: SCK pin number
 void initialize();
+
+// Reset SD card into SPI mode to prevent MISO crosstalk
+// Sends CMD0 to tri-state SD card MISO output
+void resetSDCard();
 
 // Check if the SPI bus is currently locked by a DMA transfer
 bool isBusLocked();


### PR DESCRIPTION
puts sdcard it in a known reset mode at startup so it does not output onto display bus in unknown state